### PR TITLE
modifications to get local build/test scenario working

### DIFF
--- a/src/PSPackageProject.psm1
+++ b/src/PSPackageProject.psm1
@@ -336,9 +336,10 @@ function Invoke-PSPackageProjectTest {
     )
 
     END {
+        $config = Get-PSPackageProjectConfiguration
         if ($Type -contains "Functional" ) {
             # this will return a path to the results
-            $resultFile = Invoke-FunctionalValidation -testPath test
+            $resultFile = Invoke-FunctionalValidation -testPath $config.TestPath
             $testResults = Test-Result -path $resultFile
             ##$null = Show-Failures $testResults
         }

--- a/src/PSPackageProject.psm1
+++ b/src/PSPackageProject.psm1
@@ -655,7 +655,7 @@ function Initialize-PSPackageProject {
     $moduleSourceBase = Join-Path $ModuleRoot "src"
     $null = New-Item -ItemType Directory -Path $moduleSourceBase
     $moduleFileWithoutExtension = Join-Path $moduleSourceBase ${ModuleName}
-    New-ModuleManifest -Path "${moduleFileWithoutExtension}.psd1"
+    New-ModuleManifest -Path "${moduleFileWithoutExtension}.psd1" -CmdletsToExport "verb-noun" -RootModule "./${ModuleName}.dll"
     $null = New-Item -Type File "${moduleFileWithoutExtension}.psm1"
 
     # Create a directory for cs sources and create a classlib csproj file with
@@ -727,7 +727,7 @@ Describe "Test ${moduleName}" {
         TestPath = Join-Path $moduleRoot 'test'
         HelpPath = Join-Path $moduleRoot 'help'
         BuildOutputPath = Join-Path $moduleRoot 'out'
-        Culture = "$Culture"
+        Culture = [CultureInfo]::CurrentCulture.Name # This needs to be settable
     } | ConvertTo-Json
 
     if($(${PSVersionTable}.PSEdition) -eq 'Desktop') {

--- a/src/PSPackageProject.psm1
+++ b/src/PSPackageProject.psm1
@@ -722,11 +722,12 @@ Describe "Test ${moduleName}" {
     # make pspackageproject.json
     $jsonPrj =
     @{
-        SourcePath = 'src'
+        SourcePath = Join-Path $moduleRoot "src"
         ModuleName = "${ModuleName}"
-        TestPath = 'test'
-        HelpPath = 'help'
-        BuildOutputPath = 'out'
+        TestPath = Join-Path $moduleRoot 'test'
+        HelpPath = Join-Path $moduleRoot 'help'
+        BuildOutputPath = Join-Path $moduleRoot 'out'
+        Culture = "$Culture"
     } | ConvertTo-Json
 
     if($(${PSVersionTable}.PSEdition) -eq 'Desktop') {


### PR DESCRIPTION
Here's the scenario that works end to end

```powershell
PS> import-module -force ./PSPackageProject.psd1
PS> Initialize-PSPackageProject -modulename mymod -ModuleBase /tmp/mb                                 
PS> cd /tmp/mb      
/tmp/mb
PS> ./build -build
VERBOSE: Invoking build script
VERBOSE: Starting DoBuild
VERBOSE: Copying module files to '/tmp/mb/out/mymod'
VERBOSE: Copying help files to '/tmp/mb/out/mymod'
VERBOSE: Building assembly and copying to '/tmp/mb/out/mymod'
VERBOSE: Ending DoBuild
VERBOSE: Finished invoking build script
PS> ./build -test
WARNING: The names of some imported commands from the module 'mymod' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.
Executing all tests in 'Test'

Executing script /private/tmp/mb/Test/mymod.Tests.ps1

  Describing Test mymod
    [+] This is the first test for mymod 82ms
Tests completed in 347ms
Tests Passed: 1, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0 
```

Questionable code is the call to the test code, still missing is the help building code