### PR TITLE
Pass force for Initialize-PsPackageProject to new-item -type directory

### DIFF
--- a/src/PSPackageProject.psm1
+++ b/src/PSPackageProject.psm1
@@ -745,7 +745,7 @@ function Initialize-PSPackageProject {
     if ( ! $ModuleRoot ) {
         $ModuleRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ModuleBase)
     }
-    $null = New-Item -ItemType Directory -Path $ModuleRoot
+    $null = New-Item -ItemType Directory -Path $ModuleRoot -Force:$force
 
     # make pspackageproject.json
     $jsonPrj =


### PR DESCRIPTION
this fixes the error message that you see if the modulebase exists and you use `-force` with `Initialize-PsPackageProject'